### PR TITLE
check to see if the item is actually fuel before trying to calculate the value

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -351,10 +351,14 @@ function calculate_fuel_amount()
 				if not chest.is_empty() then
 					local reactorChestPotential = 0
 					for assemblyType, count in pairs(chest.get_contents()) do
-						reactorChestPotential = reactorChestPotential + (fuelAssemblyPotential[assemblyType][1] * count)
+						if fuelAssemblyPotential[assemblyType] ~= nil then
+							reactorChestPotential = reactorChestPotential + (fuelAssemblyPotential[assemblyType][1] * count)
+						--else
+						--	game.players[1].print("non fuel item in fuel chest: " .. assemblyType)
+						end
 					end
 					LReactorAndChest[3] = reactorChestPotential
-				else 
+				else
 					LReactorAndChest[3] = 0
 				end
 			else


### PR DESCRIPTION
A friend of mine accidentally chucked a whole load of random pipes and other junk into our reactor and caused a meltdown.

fixes #6
